### PR TITLE
Fix  case insentitive common word check

### DIFF
--- a/zippy.py
+++ b/zippy.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup, NavigableString
 import argparse
 import os
 
+__version__ = "1.0.0"
 
 def parse_algorithm(algorithm):
     try:
@@ -89,6 +90,7 @@ if __name__ == "__main__":
     parser.add_argument('input', help="Input ePub file path")
     parser.add_argument('output', help="Output ePub file path")
     parser.add_argument('--algorithm', default="- 0 1 1 2 0.4", help="Bionification algorithm")
+    parser.add_argument('-v', '--version', action='version', version=f'%(prog)s {__version__}')
     args = parser.parse_args()
 
     bionify_ebook(args.input, args.output, args.algorithm)

--- a/zippy.py
+++ b/zippy.py
@@ -34,7 +34,7 @@ def parse_algorithm(algorithm):
 
 def bionify_word(word, algorithm, common_words):
     def is_common(word):
-        return word in common_words
+        return word.lower() in common_words
 
     index = len(word) - 1
     num_bold = 1


### PR DESCRIPTION
The Problem:

When checking if a word is a common word, the original function does not account for capitalization. This can lead to cases where a capitalized common word (e.g., "The") is not recognized as a common word because the check is case-sensitive.

Fix:

Convert each word to lowercase, so the function can correctly identify common words regardless of whether they are capitalized in the text.

This PR also adds a -v and --version flag to zippy. 

Credit: https://github.com/nimish-ks/zippy/issues/1